### PR TITLE
xAOD integration

### DIFF
--- a/src/AnalysisPackage/AnalysisPackage/TestClass.h
+++ b/src/AnalysisPackage/AnalysisPackage/TestClass.h
@@ -1,0 +1,12 @@
+#ifndef TESTCLASS_H
+#define TESTCLASS_H
+
+#include <vector>
+class TestClass{
+    public:
+        TestClass();
+        int runit(int a, int b);
+        std::vector<double> test_create_container();
+};
+
+#endif

--- a/src/AnalysisPackage/CMakeLists.txt
+++ b/src/AnalysisPackage/CMakeLists.txt
@@ -5,7 +5,20 @@ atlas_subdir (AnalysisPackage)
 atlas_add_library( AnalysisPackageLib
    AnalysisPackage/*.h Root/*.cxx
    PUBLIC_HEADERS AnalysisPackage
-   LINK_LIBRARIES AnaAlgorithmLib )
+   LINK_LIBRARIES
+   AnaAlgorithmLib
+   xAODEgamma
+   xAODCore
+)
+
+atlas_add_executable( AnalysisPackageRunner
+   util/run.cxx
+   LINK_LIBRARIES
+   AnalysisPackageLib
+)
+
+
+
 
 atlas_add_dictionary( AnalysisPackageDict
    AnalysisPackage/AnalysisPackageDict.h

--- a/src/AnalysisPackage/Root/TestClass.cxx
+++ b/src/AnalysisPackage/Root/TestClass.cxx
@@ -1,0 +1,36 @@
+#include "AnalysisPackage/TestClass.h"
+#include "xAODEgamma/ElectronContainer.h"
+#include "xAODEgamma/Electron.h"
+#include <xAODCore/AuxContainerBase.h>
+#include <iostream>
+
+TestClass::TestClass(){
+    
+}
+
+int TestClass::runit(int a, int b){
+    return a+b;
+}
+
+
+std::vector<double> TestClass::test_create_container(){
+   auto electrons = std::make_unique<xAOD::ElectronContainer>();
+   auto ele_aux = std::make_unique<xAOD::AuxContainerBase>();
+   electrons->setStore (ele_aux.get());
+
+   std::cout << "ok created container" << std::endl;
+
+   for (int i = 0; i < 10; ++i) {
+    std::cout << "ok create ele" << std::endl;
+      auto ele = new xAOD::Electron();
+      electrons->push_back(ele);
+      ele->setPt(i);
+      std::cout << "added electron with " << electrons->at(i)->pt() << std::endl;
+   }
+   std::cout << "preparer output column" << std::endl;
+   std::vector<double> r;
+   for(auto ele : *electrons){
+       r.push_back(ele->pt());
+   }
+   return r;
+}

--- a/src/AnalysisPackage/util/run.cxx
+++ b/src/AnalysisPackage/util/run.cxx
@@ -1,0 +1,16 @@
+#include <iostream>
+#include "AnalysisPackage/TestClass.h"
+
+
+int main(){
+    std::cout << "hello" << std::endl;
+    auto getc = TestClass().test_create_container();
+
+    for(auto x : getc){
+        std::cout << x << " ,";
+    }
+    std::cout << "\n";
+
+    std::cout << "bye" << std::endl;
+    return 0;
+}

--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -1,4 +1,9 @@
 # include(GNUInstallDirs)
 
 pybind11_add_module(_AnalysisPackage module.cpp)
-target_link_libraries(_AnalysisPackage PRIVATE AnalysisPackageLib Python::Python)
+target_link_libraries(
+    _AnalysisPackage 
+    PRIVATE
+    AnalysisPackageLib
+    Python::Python
+)

--- a/src/bindings/module.cpp
+++ b/src/bindings/module.cpp
@@ -1,11 +1,37 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+
+#include "AnalysisPackage/TestClass.h"
+
+namespace py = pybind11;
 
 int add(int i, int j) {
-    return i + j;
+    TestClass c;
+    return c.runit(i,j);
 }
+
+py::array_t<double> column_maker(){
+
+    TestClass c;
+    auto cont = c.test_create_container();
+    
+    auto result = py::array_t<double>(cont.size());
+    py::buffer_info buf3 = result.request();
+    double* ptr3 = (double*)buf3.ptr;
+
+    for (unsigned int i = 0; i < buf3.shape[0]; i++)
+    {
+        ptr3[i] = cont[i];
+    }
+
+    return result;
+}
+
 
 PYBIND11_MODULE(_AnalysisPackage, m) {
     m.doc() = "pybind11 example plugin"; // optional module docstring
 
     m.def("add", &add, "A function which adds two numbers");
+    m.def("column_maker", &column_maker, "A function that produces a column from xAOD");
 }

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -4,3 +4,6 @@ import _AnalysisPackage
 def test_add():
     assert _AnalysisPackage.add(1, 2) == 3
     assert _AnalysisPackage.add(1, -1) == 0
+
+def test_column():
+    assert _AnalysisPackage.column_maker().tolist() == list(range(10))


### PR DESCRIPTION
this is a first dummy example that

* defines a class `TestClass` that has a method `test_create_container` that 
  *  creates a `xAOD::ElectronContainer`
  *  fills it with `xAOD::Electrons`
  * creates a std:vector<double> from a `xAOD::ElectronContainer`
  

* adds a pybind  method that
  * exposes this `std::vector<double>` generating method to python
  * by returning a numpy array

@kratsg @matthewfeickert @gordonwatts @jpivarski

there is likely a lot of overhead and it's not zero-copy - but it's a start!


```
>>> import _AnalysisPackaage
>>> _AnalysisPackage.column_maker()
array([0., 1., 2., 3., 4., 5., 6., 7., 8., 9.])
```