### PR TITLE
ci: Add GitHub Actions based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+  # Run weekly on Sunday at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.image }}
+      options: --user root
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        image: ["atlas/analysisbase:22.2.27"]
+
+    steps:
+
+    # Forced to use checkout@v1 as CentOS 7's Git version is too old
+    # to use checkout@v2 (needs Git v2.18+)
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Build with ATLAS CMake
+      run: |
+        bash build.sh
+
+    - name: Check working environment variables
+      run: |
+        printf '#!/bin/bash\n\n. setup.sh\nprintenv\n' > /tmp/_printenv.sh
+        bash /tmp/_printenv.sh
+
+    - name: Run tests with pytest
+      run: |
+        bash test_runner.sh

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,23 @@
-default: debug-image
+default: debug
 
-debug-image:
-	docker pull atlas/analysisbase:22.2.27
+debug:
 	docker run --rm -ti \
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
 		atlas/analysisbase:22.2.27
 
+build-docker:
+	docker pull atlas/analysisbase:22.2.27
+	docker run --rm -ti \
+		-v $(shell pwd):$(shell pwd) \
+		-w $(shell pwd) \
+		atlas/analysisbase:22.2.27 \
+		/bin/bash -c 'bash build.sh'
+
+ci-docker:
+	docker pull atlas/analysisbase:22.2.27
+	docker run --rm -ti \
+		-v $(shell pwd):$(shell pwd) \
+		-w $(shell pwd) \
+		atlas/analysisbase:22.2.27 \
+		/bin/bash -c 'bash tests/ci.sh'

--- a/README.md
+++ b/README.md
@@ -2,8 +2,19 @@
 
 ## Getting Started
 
+```console
+$ make debug
 ```
-make 
-bash build.sh
-bash test_runner.sh
+
+### Build locally in an AnalysisBase Docker image
+
+```console
+$ make build-docker
+$ make debug
+```
+
+### Build and run tests locally in an AnalysisBase Docker image
+
+```console
+$ make ci-docker
 ```

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -6,8 +6,12 @@ set -o pipefail
 
 . setup.sh
 
+# Place .local/bin on PATH for pytest
+export PATH="${HOME}/.local/bin:${PATH}"
+
 # Ensure testing dependencies
-python -m pip --quiet install --upgrade pip setuptools wheel
-python -m pip install --upgrade --requirement test-requirements.txt
+python -m pip --quiet install --user --upgrade pip setuptools wheel
+python -m pip install --user --upgrade --requirement test-requirements.txt
+python -m pip list
 
 python -m pytest -sx tests

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+bash build.sh
+
+printenv
+
+bash test_runner.sh


### PR DESCRIPTION
Add CI in GHA (with some help from @henryiii) and add equivalent in local Docker image. For reasons I don't fully understand, GitHub Action's `container` option doesn't like scripts being sourced, and so all steps are run in Bash subshells.

**Squash and merge commit message**
```
* Place $HOME/.local/bin on PATH and pip install as user
   - Avoid pip warnings about write permissions
* Add a ci script to tests
   - Allows to run CI like workflow in Docker
* Revise Makefile and update README
* Add GitHub Actions based CI
   - Given ancient version of Git in CentOS 7 _required_ to use actions/checkout@v1
   - Thanks to @henryiii for the suggestion https://twitter.com/HenrySchreiner3/status/1403223427230601220
   - As using container option, need to run in a subshell instead of sourcing
```