### PR TITLE
chore: Improve Docker functionality with additional Make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+core
 
 *.py[co]
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,14 @@ build-docker:
 		atlas/analysisbase:22.2.27 \
 		/bin/bash -c 'bash build.sh'
 
+tests-docker:
+	docker pull atlas/analysisbase:22.2.27
+	docker run --rm -ti \
+		-v $(shell pwd):$(shell pwd) \
+		-w $(shell pwd) \
+		atlas/analysisbase:22.2.27 \
+		/bin/bash -c 'bash test_runner.sh'
+
 ci-docker:
 	docker pull atlas/analysisbase:22.2.27
 	docker run --rm -ti \
@@ -21,3 +29,7 @@ ci-docker:
 		-w $(shell pwd) \
 		atlas/analysisbase:22.2.27 \
 		/bin/bash -c 'bash tests/ci.sh'
+
+clean-artifacts: $(eval SHELL:=/bin/bash)
+	if [ -d build ]; then rm -rf build; fi
+	if [ -f core ]; then rm core; fi

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,35 @@
 default: debug
 
+image = atlas/analysisbase:22.2.27
+
 debug:
 	docker run --rm -ti \
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
-		atlas/analysisbase:22.2.27
+		$(image)
 
 build-docker:
-	docker pull atlas/analysisbase:22.2.27
+	docker pull $(image)
 	docker run --rm -ti \
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
-		atlas/analysisbase:22.2.27 \
+		$(image) \
 		/bin/bash -c 'bash build.sh'
 
 tests-docker:
-	docker pull atlas/analysisbase:22.2.27
+	docker pull $(image)
 	docker run --rm -ti \
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
-		atlas/analysisbase:22.2.27 \
+		$(image) \
 		/bin/bash -c 'bash test_runner.sh'
 
 ci-docker:
-	docker pull atlas/analysisbase:22.2.27
+	docker pull $(image)
 	docker run --rm -ti \
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
-		atlas/analysisbase:22.2.27 \
+		$(image) \
 		/bin/bash -c 'bash tests/ci.sh'
 
 clean-artifacts: $(eval SHELL:=/bin/bash)


### PR DESCRIPTION
* Parameterizes the Docker image used for easier local checks across AnalysisBase releases
* Add `test-docker` Make target that assumes `build-docker` has already been run and just executes the test suite
* Add `clean-artifacts` Make target that cleans up build artifacts if they exist
   - Envoke Bash shell to be able to use Bash logic